### PR TITLE
Feature/issue 4.8 map implementation

### DIFF
--- a/App.js
+++ b/App.js
@@ -10,6 +10,7 @@ import ViewRequestScreen from './screen/ViewRequestScreen';
 import AcceptOrderScreen from './screen/AcceptOrderScreen';
 import SearchScreen from './screen/SearchScreen';
 import CreateStoreRequestScreen from './screen/CreateStoreRequestScreen';
+import NavigationToLocationScreen from "./screen/NavigationToLocationScreen";
 
 const Stack = createStackNavigator();
 
@@ -26,6 +27,7 @@ const App = () => {
         <Stack.Screen name="AcceptOrderScreen" component={AcceptOrderScreen} />
         <Stack.Screen name="Search Items" component={SearchScreen } />
         <Stack.Screen name="CreateStoreRequestScreen" component={CreateStoreRequestScreen} />
+        <Stack.Screen name="NavigationToLocationScreen" component={NavigationToLocationScreen} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/README.md
+++ b/README.md
@@ -486,5 +486,8 @@ OK (4 tests, 4 assertions)
 
 #### Before running, need to run following command in terminal:
 npm install @react-native-picker/picker
+npm install react-native-maps (not sure weather this is correct)
+expo install react-native-maps (this is working)
+npm install react-native-maps react-native-google-places-autocomplete
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "expo-status-bar": "~2.0.1",
         "react": "18.3.1",
         "react-native": "^0.76.9",
+        "react-native-maps": "1.18.0",
         "react-native-safe-area-context": "4.12.0",
         "react-native-screens": "~4.4.0"
       },
@@ -3749,6 +3750,12 @@
       "dependencies": {
         "@babel/types": "^7.20.7"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
@@ -9072,6 +9079,28 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-maps": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-1.18.0.tgz",
+      "integrity": "sha512-S17nYUqeMptgIPaAZuVRo+eRelPreBBYQWw6jsxU7qQ12p+THSfFaqabcNn7fBmsXhT3T27iIl8ek8v1H8BaGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.13"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": ">= 17.0.1",
+        "react-native": ">= 0.64.3",
+        "react-native-web": ">= 0.11"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-native-safe-area-context": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "react": "18.3.1",
     "react-native": "^0.76.9",
     "react-native-safe-area-context": "4.12.0",
-    "react-native-screens": "~4.4.0"
+    "react-native-screens": "~4.4.0",
+    "react-native-maps": "1.18.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/screen/AcceptOrderScreen.js
+++ b/screen/AcceptOrderScreen.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { View, Text, Button, StyleSheet, Alert, FlatList } from "react-native";
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import MapView, { Marker, PROVIDER_DEFAULT } from 'react-native-maps';
 
 const AcceptOrderScreen = ({ route, navigation }) => {
   const { username = 'Unknown', role = 'user' } = route.params ?? {};
@@ -121,15 +122,31 @@ const AcceptOrderScreen = ({ route, navigation }) => {
         <Text style={styles.statusText}>{item.status.toUpperCase()}</Text>
       </View>
 
-      {item.status === "pending" && (
-        <Button title="Accept" onPress={() => handleAcceptOrder(item.id)} />
-      )}
+    {item.status === "pending" && (
+      <Button
+        title="Accept"
+        onPress={() => handleAcceptOrder(item.id)}
+      />
+    )}
 
-      {item.status === "accepted" && (
-        <Button title="Drop Off" onPress={() => handleDropOffOrder(item.id)} />
-      )}
-    </View>
-  );
+    {item.status === "accepted" && (
+      <>
+        <Button
+          title="Drop Off"
+          onPress={() => handleDropOffOrder(item.id)}
+        />
+        <Button
+          title="Navigate"
+          onPress={() =>
+            navigation.navigate("NavigationToLocationScreen", {
+              dropOffLocation: item.drop_off_location,
+            })
+          }
+        />
+      </>
+    )}
+  </View>
+);
 
   return (
     <View style={styles.container}>

--- a/screen/CreateRequestScreen.js
+++ b/screen/CreateRequestScreen.js
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from "react";
-import { View, Text, TextInput, Button, Alert, StyleSheet } from "react-native";
+import { View, Text, TextInput, Button, Alert, StyleSheet, ScrollView} from "react-native";
 import { Picker } from "@react-native-picker/picker";
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import MapView, { Marker, PROVIDER_DEFAULT } from 'react-native-maps';
 
 const CreateRequestScreen = ({ route, navigation }) => {
   const { username = 'Unknown', role = 'user' } = route.params ?? {};
@@ -11,6 +12,13 @@ const CreateRequestScreen = ({ route, navigation }) => {
   const [dropOffLocation, setDropOffLocation] = useState("");
   const [deliverySpeed, setDeliverySpeed] = useState("common");
   const [sessionID, setSessionID] = useState(null);
+  const [region, setRegion] = useState({
+    latitude: 37.78825,  // Default coordinates (Not right now)
+    longitude: -122.4324,
+    latitudeDelta: 0.0922,
+    longitudeDelta: 0.0421,
+  });
+  const [marker, setMarker] = useState(null);
 
 useEffect(() => {
   (async () => {
@@ -113,9 +121,18 @@ const createOrder = async () => {
     Alert.alert("Error", "Failed to create request. Please try again.");
   }
 };
-
+  const handleMapPress = (e) => {
+    const coordinate = e.nativeEvent.coordinate;
+    setMarker(coordinate);
+    setDropOffLocation(`${coordinate.latitude}, ${coordinate.longitude}`);
+  };
   return (
-    <View style={styles.container}>
+  <ScrollView
+    style={styles.scrollView}
+    contentContainerStyle={styles.contentContainer}
+    nestedScrollEnabled={true}
+  >
+    <View>
     <View style={styles.infoContainer}>
       <Text style={styles.infoText}>Logged in as: {username}</Text>
       <Text style={styles.infoText}>
@@ -164,9 +181,24 @@ const createOrder = async () => {
           color={deliverySpeed === "common" ? "blue" : "gray"}
         />
       </View>
-
+      <MapView
+        style={styles.map}
+        provider={PROVIDER_DEFAULT}  // Use OSM provider
+        region={region}
+        onRegionChangeComplete={setRegion}
+        onPress={handleMapPress}
+      >
+        {marker && (
+          <Marker
+            coordinate={marker}
+            title="Drop-off Location"
+            description="This is the location you selected."
+          />
+        )}
+      </MapView>
       <Button title="Create Request" onPress={handleSubmit} />
     </View>
+    </ScrollView>
   );
 };
 
@@ -197,6 +229,19 @@ const styles = StyleSheet.create({
       borderColor: '#eee',
       marginBottom: 12,
     },
+  map: {
+    width: '100%',
+    height: 200,
+    marginTop: 20,
+  },
+  scrollView: {
+     flex: 1,
+  },
+  contentContainer: {
+    flexGrow: 1,
+    padding: 20,
+    backgroundColor: "#fff",
+  },
 });
 
 export default CreateRequestScreen;

--- a/screen/CreateRequestScreen.js
+++ b/screen/CreateRequestScreen.js
@@ -13,8 +13,8 @@ const CreateRequestScreen = ({ route, navigation }) => {
   const [deliverySpeed, setDeliverySpeed] = useState("common");
   const [sessionID, setSessionID] = useState(null);
   const [region, setRegion] = useState({
-    latitude: 37.78825,  // Default coordinates (Not right now)
-    longitude: -122.4324,
+    latitude: 41.5556,     // Wesleyan University
+    longitude: -72.6558,
     latitudeDelta: 0.0922,
     longitudeDelta: 0.0421,
   });

--- a/screen/NavigationToLocationScreen.js
+++ b/screen/NavigationToLocationScreen.js
@@ -1,0 +1,73 @@
+import React from "react";
+import {
+  View,
+  Button,
+  Platform,
+  Alert,
+  StyleSheet,
+} from "react-native";
+import MapView, { Marker } from "react-native-maps";
+import { Linking } from "react-native";
+
+const NavigationToLocation = ({ route, navigation }) => {
+  const { dropOffLocation } = route.params;
+  // “12.3456, -78.9012”
+  const [lat, lng] = dropOffLocation
+    .split(",")
+    .map((s) => parseFloat(s.trim()));
+
+  const startNavigation = () => {
+    const url = Platform.select({
+      ios: `maps://?daddr=${lat},${lng}`,
+      android: `google.navigation:q=${lat},${lng}`,
+    });
+    Linking.openURL(url).catch((err) =>
+      Alert.alert("Error", "Could not open maps: " + err)
+    );
+  };
+
+  return (
+    <View style={styles.container}>
+      <MapView
+        style={styles.map}
+        initialRegion={{
+          latitude: lat,
+          longitude: lng,
+          latitudeDelta: 0.01,
+          longitudeDelta: 0.01,
+        }}
+      >
+        <Marker
+          coordinate={{ latitude: lat, longitude: lng }}
+          title="Drop‑off"
+        />
+      </MapView>
+      <View style={styles.buttonWrapper}>
+        <Button title="Start Navigation" onPress={startNavigation} />
+              <View style={styles.backButton}>
+                <Button
+                  title="Back to Dashboard"
+                  onPress={() => navigation.goBack()}
+                />
+              </View>
+      </View>
+    </View>
+  );
+};
+
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  map: { flex: 1 },
+  buttonWrapper: {
+    position: "absolute",
+    bottom: 20,
+    left: 20,
+    right: 20,
+  },
+  backButton: {
+    marginTop: 10,
+  },
+});
+
+export default NavigationToLocation;


### PR DESCRIPTION
Added map function
Before testing setup:
1. run  expo install react-native-maps (this is working)
2. run npm install react-native-maps react-native-google-places-autocomplete
3. If there are any more problems, please try to :
rm -rf node_modules
rm package-lock.json
npm install
Then do steps 1 and 2

It should: 
In CreateRequestScreen.js: show a map that could be clicked on, and choose a coordinate as a drop-off location
In AcceptOrderScreen.js: after the order is accepted, show a navigate button, by clicking it, then click ‘start navigation’, it will navigate you to an external map (a different screen), you can go back to the app by swiping the screen from bottom to top and back to WesDash app screen.
